### PR TITLE
Fixed wrong default parameter in extract_core_and_interface

### DIFF
--- a/graphlearn/graphlearn.py
+++ b/graphlearn/graphlearn.py
@@ -324,8 +324,6 @@ class GraphLearnSampler(object):
         for core_hash in hashes:
             yield self.local_substitutable_graph_grammar.grammar[cip.interface_hash][core_hash]
 
-        raise Exception('select_randomized_cips_from_grammar didn\'t find any acceptable cip; entries_found %d' %
-                        len(hashes))
 
     def filter_chips_get_core_hashes(self,cip):
         '''

--- a/graphlearn/graphtools.py
+++ b/graphlearn/graphtools.py
@@ -76,7 +76,7 @@ def calc_node_name(interfacegraph, node, hash_bitmask):
 
 
 def extract_core_and_interface(root_node, graph, radius_list=None, thickness_list=None, vectorizer=None,
-                               hash_bitmask=2 * 20 - 1, node_entity_check= lambda x,y:True):
+                               hash_bitmask=2 ** 20 - 1, node_entity_check= lambda x,y:True):
     """
 
 :param root_node: root root_node


### PR DESCRIPTION
Fixed wrong default parameter in extract_core_and_interface.

Removed exception in select_randomized_cips_from_grammar.
